### PR TITLE
[fix] 종목명 검색 시 차트 재렌더링 문제 해결

### DIFF
--- a/frontend/src/components/Chart/index.js
+++ b/frontend/src/components/Chart/index.js
@@ -3,17 +3,17 @@ import HighStock from "highcharts/highstock";
 import HighchartsReact from "highcharts-react-official";
 
 
-export default function HighChart({ configs }) {
+export const HighChart = React.memo(function ({ configs, name }) {
     const [key, setKey] = useState(0);
     useEffect(() => {
         async function rerender(){
             setTimeout(() => {
-                setKey(key + 1);
+                setKey(name);
             }, 0);
         }
         
         rerender();
-    }, [configs]);
+    }, [name]);
     return (
         <HighchartsReact
                 key={key}
@@ -23,4 +23,4 @@ export default function HighChart({ configs }) {
             />
         
     )
-}
+},(prevProps,nextProps)=>prevProps.name===nextProps.name);

--- a/frontend/src/components/ChartContainer/index.js
+++ b/frontend/src/components/ChartContainer/index.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react";
 import { fetchChartData, fetchPrediction } from "../../hooks/useChart";
 import { Loading } from "../../pages";
-import HighChart from "../Chart";
+import {HighChart} from "../Chart";
 import { config } from "../Chart/chartUtil";
 import { ChartView, Inner, PredictionDiv, PredictionInfo, Predictionlbl, PredictionResult, PredictionSpan, PredictionTitle } from "./style";
 

--- a/frontend/src/components/SimulateTrade/index.js
+++ b/frontend/src/components/SimulateTrade/index.js
@@ -5,7 +5,7 @@ import { fetchUserInfo } from "../../hooks/useMyInfo";
 import { fetchCurPrice, fetchTrade } from "../../hooks/useTrade";
 import { Loading } from "../../pages";
 import { userAtom } from "../../store/user";
-import HighChart from "../Chart";
+import {HighChart} from "../Chart";
 import { config } from "../Chart/chartUtil";
 
 import { AmountInput, Chart, ChartGroup, ChartHeader, ChartInfo, ChartList, ChartListCode, ChartListData, ChartListGroup, ChartListHead, ChartListInput, ChartListName, ChartTitle, Inner, OrderBtn, OrderRow, Prediction, PredictionDiv, PredictionResult, PredictionSpan, PredictionSpec, ToggleBtn, Trade, TradeToggle } from "./style";
@@ -42,7 +42,7 @@ export default function SimulateTrade() {
         }
 
         setStocks();
-    }, [stockName])
+    }, [])
 
     if (loading)
         return <Loading />
@@ -183,7 +183,7 @@ export default function SimulateTrade() {
                         }
                     </ChartHeader>
                     <div style={{ margin: "10px",marginTop: "20px" }}>
-                        <HighChart configs={chartConfig} />
+                        <HighChart configs={chartConfig} name={curStockName}/>
                     </div>
                 </Chart>
             
@@ -191,7 +191,10 @@ export default function SimulateTrade() {
                     <ChartListHead>
                         <ChartListInput
                             placeholder={"종목명 입력"}
-                            onChange={(e) => setStockName(e.target.value)}
+                            onChange={(e) => {
+                                e.preventDefault();
+                                setStockName(e.target.value);
+                            }}
                         />
                     </ChartListHead>
                     <ChartListGroup>


### PR DESCRIPTION
### 구현 내용

- HighChart에 props로 현재 설정된 종목명을 넣음으로써 재렌더링 방지